### PR TITLE
[김기현] add : kakao_login API

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -2,7 +2,7 @@ import pymysql
 
 from pathlib import Path
 
-from my_settings import SECRET_KEY, DATABASES
+from my_settings import SECRET_KEY, ALGORITHM, DATABASES
 
 pymysql.install_as_MySQLdb()
 
@@ -15,7 +15,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = SECRET_KEY
-
+ALGORITHM = ALGORITHM
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,4 +2,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path("rooms", include('rooms.urls')),
+    path("users", include('users.urls')),
 ]

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,144 @@
-from django.test import TestCase
+import jwt
+from unittest.mock import MagicMock, patch
+from unittest      import mock
+from datetime      import datetime, timedelta
 
-# Create your tests here.
+from django.test   import TestCase, Client
+
+from users.models  import User
+from my_settings   import SECRET_KEY, ALGORITHM
+
+
+class KakaoSignInTest(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id       = 1,
+            kakao_id = 2162014437,
+            nickname = '김기현',
+            email    = 'kimgh6516@naver.com',
+            gender   = 'male',
+            profile_image = 'http://k.kakaocdn.net/'
+        )
+        
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch("users.views.requests")
+    def test_kakao_signin_create_user_success(self, mocked_requests):
+        client = Client()
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                "id": 2162014437,
+                "properties": {
+                    "nickname": "김기현",
+                },
+                "kakao_account": {
+                    "profile": {
+                    "profile_image_url": "http://k.kakaocdn.net/",
+                    "nickname": "김기현",
+                    },
+                    "email": "kimgh6516@naver.com",
+                    "birthday": "1102",
+                    "gender": "male"
+                }
+            }
+        
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_Authorization' : 'fake_access_token'}
+        response            = client.get('/users/login/kakao/callback', **headers)  
+        user                = User.objects.get(kakao_id=2162014437)
+        access_token        = jwt.encode(
+                                {'user_id' : user.id, 
+                                    'exp': datetime.utcnow() + timedelta(hours=24)
+                                    }, SECRET_KEY, ALGORITHM)
+        results             = {
+                'email'         : "kimgh6516@naver.com",
+                'nickname'      : "김기현",
+                'profile_image' : "http://k.kakaocdn.net/",
+                'gender'        : "male",
+                'kakao_id'      : 2162014437
+            }  
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {
+                'message'   : 'SUCCESS',
+                'token'     : access_token,
+                'results'   : results,
+                })                                    
+  
+    @patch("users.views.requests")
+    def test_kakao_signin_create_user_invalid_form_fail(self, mocked_requests):
+        client = Client()
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                "id": 2162014437,
+                "properties": {
+                    "nickname": "김기현",
+                },
+                "kakao_account": {
+                    "profile": {
+                    "nickname": "김기현",
+                    },
+                    "birthday": "1102",
+                    "gender": "male"
+                }
+            }
+        
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_Authorization' : 'fake_access_token'}
+        response            = client.get('/users/login/kakao/callback', **headers)  
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.json(), {'message': 'EMAIL_REQUIRED'})   
+
+    @patch("users.views.requests")
+    def test_kakao_signin_invalid_token_form_fail(self, mocked_requests):
+        client = Client()
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                "id": 2162014437,
+                "properties": {
+                    "nickname": "김기현",
+                },
+                "kakao_account": {
+                    "profile": {
+                    "profile_image_url": "http://k.kakaocdn.net/",
+                    "nickname": "김기현",
+                    },
+                    "email": "kimgh6516@naver.com",
+                    "birthday": "1102",
+                    "gender": "male"
+                }
+            }
+        
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        response            = client.get('/users/login/kakao/callback')
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {'message' : 'INVALID ACCESS TOKEN'})
+    
+    @patch("users.views.requests")
+    def test_kakao_signin_key_error_fail(self, mocked_requests):
+        client = Client()
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                "id": 2162014437,
+                "kakao_account": {
+                    "profile": {
+                    },
+                    "email": "kimgh6516@naver.com",
+                }
+            }
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_Authorization' : 'fake_access_token'}
+        response            = client.get('/users/login/kakao/callback', **headers)  
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message' : 'CANNOT_GET_ATTRIBUTE'},)   

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from users.views import KakaoSignIn
+
+urlpatterns = [
+    path("/login/kakao", KakaoSignIn.as_view()),
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,70 @@
-from django.shortcuts import render
+import requests, jwt, datetime
 
-# Create your views here.
+from django.views import View
+from django.http  import JsonResponse
+
+from users.models import User
+from my_settings  import SECRET_KEY, ALGORITHM
+
+class KakaoSignIn(View):
+    def get(self, request):
+        try:
+            kakao_token = request.headers.get("Authorization")
+            
+            if kakao_token == None:
+                return JsonResponse({"message":"INVALID_ACCESS_TOKEN"}, status=401)
+            
+            profile_request = requests.get(
+                "https://kapi.kakao.com/v2/user/me",
+                headers = {"Authorization": f"Bearer {kakao_token}"},
+                timeout = 2
+            )      
+  
+            profile_json  = profile_request.json()
+            email         = profile_json.get("kakao_account").get("email", None)
+            nickname      = profile_json.get("properties").get("nickname")
+            profile_image = profile_json.get("kakao_account").get("profile").get("profile_image_url", None)
+            gender        = profile_json.get("kakao_account").get("gender", None)
+            kakao_id      = profile_json.get("id")
+            
+            if email is None:
+                return JsonResponse({'message': 'EMAIL_REQUIRED'}, status = 405)
+            
+            if kakao_id is None:
+                return JsonResponse({"message":"KAKAO_TOKEN_ERROR"}, status=403)
+            
+            user, is_created = User.objects.get_or_create(
+                kakao_id      = kakao_id,
+                defaults={
+                    'email'         : email,
+                    'nickname'      : nickname,
+                    'profile_image' : profile_image,
+                    'gender'        : gender
+                }
+            )
+                
+            payload = {
+                'user_id' : user.id, 
+                'exp': datetime.datetime.utcnow() + datetime.timedelta(hours=24)
+            }    
+            access_token = jwt.encode(payload, SECRET_KEY, ALGORITHM)
+           
+            results = {
+                'email'         : email,
+                'nickname'      : nickname,
+                'profile_image' : profile_image,
+                'gender'        : gender,
+                'kakao_id'      : kakao_id
+            }               
+    
+            return JsonResponse({
+                    'message'   : 'SUCCESS',
+                    'token'     : access_token,
+                    'results'   : results
+                }, status = 201)                                    
+
+        except AttributeError:
+            return JsonResponse({'message' : 'CANNOT_GET_ATTRIBUTE'}, status = 400)
+            
+        except jwt.ExpiredSignatureError:
+            return JsonResponse({'message' : 'EXPIRED_TOKEN'}, status = 400)  


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 로그인 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- Create login callback함수 
- 카카오 REST API 를 이용하여 회원정보 요청
- get_or_create 메소드를 사용하여 데이터베이스 관리
- test) 테스트 완료(유저 생성 성공/ 유효하지 않은 토큰 사용, 이메일 누락, 빈 속성 '에러 실패' 확인)
- test) get을 사용하여 빈 값일 경우 ""로 저장, 해당 속성이 비어있으면 AttributeError return 확인
- feedback) payload 활용
- feedback) conventioning
<img width="1266" alt="스크린샷 2022-03-16 오후 5 02 07" src="https://user-images.githubusercontent.com/60570733/158543861-583554c8-8819-423a-b497-8b88b76754e5.png">
<img width="1615" alt="스크린샷 2022-03-16 오후 5 02 25" src="https://user-images.githubusercontent.com/60570733/158543871-aa6af500-dbef-45f9-ac8e-d83bf17c4e5b.png">
<img width="1420" alt="스크린샷 2022-03-18 오후 9 51 34" src="https://user-images.githubusercontent.com/60570733/159006175-57608ab1-a541-4129-ac39-877c6eee42ca.png">

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 사용자가 발생시킬 수 있는 다양한 예외 케이스에 대해 고민하게 되었습니다. (예시)
- 문자열 데이터 입력 시 마지막에 빈 문자열이 포함되어 있는 경우 데이터 처리가 올바르게 되지 않아 유효성 검사에 빈 문자열 제거하는 로직을 추가하였습니다. (예시)
- Kakao Developer REST api docoment 참고하여 프론트랑 연결을 가정하여 test
- OAuth2 Flow와 callback을 front에서 할 때와 backend에서 할 때의 차이점 파악

<br />

## :: 기타 질문 및 특이 사항
